### PR TITLE
Automate README docs in Quarto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
+# Open Defense Research Docs
 
+This repository holds documentation built with [Quarto](https://quarto.org/).
+
+Run `scripts/generate-readmes.sh` to collect README files from submodules into the `_readmes/` folder. Generated pages will automatically appear in the sidebar navigation.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,0 +1,9 @@
+project:
+  type: website
+
+website:
+  title: "Open Defense Research"
+  sidebar:
+    contents:
+      - section: "Readmes"
+        contents: "_readmes"

--- a/scripts/generate-readmes.sh
+++ b/scripts/generate-readmes.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Generate .qmd files under _readmes/ for every README.md found in git submodules
+set -euo pipefail
+
+READMES_DIR="_readmes"
+
+mkdir -p "$READMES_DIR"
+# Remove previously generated files
+find "$READMES_DIR" -type f -name '*.qmd' -delete
+
+# Exit early if no submodules
+if [ ! -f .gitmodules ]; then
+  echo "No submodules found"
+  exit 0
+fi
+
+# Iterate over submodule paths defined in .gitmodules
+# Extract path using git config
+submodules=$(git config --file .gitmodules --get-regexp path | awk '{print $2}')
+for submodule in $submodules; do
+  # For each README.md inside the submodule
+  find "$submodule" -name README.md -print | while read -r readme; do
+    # Compute destination .qmd path mirroring README location
+    rel_path=$(realpath --relative-to=. "$readme")
+    qmd_path="$READMES_DIR/${rel_path%.md}.qmd"
+    mkdir -p "$(dirname "$qmd_path")"
+    echo "{{< include $rel_path >}}" > "$qmd_path"
+  done
+done


### PR DESCRIPTION
## Summary
- add Quarto config with sidebar for `_readmes`
- script to generate `.qmd` pages from submodule READMEs
- document generation workflow

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fa9013aa88329b98a5d73f513d2bf